### PR TITLE
feat: add model registry for per-endpoint LLM model targeting

### DIFF
--- a/src/orbit_assist/api/routes/analyze_chart.py
+++ b/src/orbit_assist/api/routes/analyze_chart.py
@@ -7,6 +7,7 @@ from google.genai import errors as genai_errors
 from google.genai import types
 
 from orbit_assist.api.deps import get_authorization_header
+from orbit_assist.core.models import get_model
 from orbit_assist.schemas.analyze_chart import (
     AnalyzeChartRequest,
     AnalyzeChartResponse,
@@ -112,7 +113,7 @@ async def analyze_chart(
 
         try:
             genai_response = await request.app.state.genai_client.aio.models.generate_content(
-                model="models/gemini-3.1-flash-lite-preview",
+                model=get_model("analyze_chart"),
                 contents=[prompt],
                 config=types.GenerateContentConfig(
                     response_mime_type="application/json",

--- a/src/orbit_assist/api/routes/entity.py
+++ b/src/orbit_assist/api/routes/entity.py
@@ -5,6 +5,7 @@ from google.genai import types, errors as genai_errors
 from orbit_assist.schemas.entity import EntityCalculatedPropertyConfig, EntityConfig, ImageUploadResponse
 from orbit_assist.api.deps import get_authorization_header
 from orbit_assist.core.entity import build_entity_payload, create_entity, fetch_configs
+from orbit_assist.core.models import get_model
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["images"])
@@ -141,7 +142,7 @@ async def upload_image(
 
     try:
         genai_response = await request.app.state.genai_client.aio.models.generate_content(
-            model="models/gemini-3.1-flash-lite-preview",
+            model=get_model("assist_entity"),
             contents=[
                 types.Part.from_bytes(data=image_contents, mime_type=file.content_type),
                 prompt,

--- a/src/orbit_assist/api/routes/suggestEntity.py
+++ b/src/orbit_assist/api/routes/suggestEntity.py
@@ -7,6 +7,7 @@ from google.genai import types, errors as genai_errors
 from orbit_assist.schemas.entity import EntityAnalysisResponse, EntityConfig, EntityConfigResponse, ListConfig, ListFilter, ListFilterTimeType, RangeContext
 from orbit_assist.api.deps import get_authorization_header
 from orbit_assist.core.entity import build_entity_payload, create_entity, fetch_configs
+from orbit_assist.core.models import get_model
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["images"])
@@ -115,7 +116,7 @@ async def suggest_entity(
 
     try:
         genai_response = await request.app.state.genai_client.aio.models.generate_content(
-            model="models/gemini-3.1-flash-lite-preview",
+            model=get_model("suggest_entity"),
             contents=[prompt],
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",

--- a/src/orbit_assist/core/analyze_jobs.py
+++ b/src/orbit_assist/core/analyze_jobs.py
@@ -3,6 +3,8 @@ from pydantic import BaseModel, Field
 from google import genai
 from typing import List
 
+from orbit_assist.core.models import get_model
+
 
 class SkillCount(BaseModel):
     name: str = Field(
@@ -35,7 +37,7 @@ async def analyze_jobs(genai_client: genai.Client, job_descriptions: List[str]):
     """
 
     response = await genai_client.aio.models.generate_content(
-        model="models/gemini-3.1-flash-lite-preview",
+        model=get_model("jobs"),
         contents=prompt,
         config={
             "response_mime_type": "application/json",

--- a/src/orbit_assist/core/models.py
+++ b/src/orbit_assist/core/models.py
@@ -1,0 +1,12 @@
+MODEL_REGISTRY: dict[str, str] = {
+    "jobs": "models/gemini-3.1-flash-lite-preview",
+    "assist_entity": "models/gemini-3.1-flash-lite-preview",
+    "suggest_entity": "models/gemini-3.1-flash-lite-preview",
+    "analyze_chart": "models/gemini-3.1-flash-lite-preview",
+}
+
+_DEFAULT_MODEL = "models/gemini-3.1-flash-lite-preview"
+
+
+def get_model(context: str) -> str:
+    return MODEL_REGISTRY.get(context, _DEFAULT_MODEL)


### PR DESCRIPTION
Introduces `core/models.py` with a `MODEL_REGISTRY` dict mapping each endpoint context key to a Gemini model name. All four LLM call sites now call `get_model("<context>")` instead of hardcoding the model string.

Closes #7

Generated with [Claude Code](https://claude.ai/code)